### PR TITLE
add ignore tag count

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,7 @@ resource "aws_security_group" "this" {
 
   lifecycle {
     ignore_changes = [
+      "tags.%",
       "tags.kubernetes.io"
     ]
   }
@@ -39,6 +40,7 @@ resource "aws_security_group" "this_name_prefix" {
   lifecycle {
     create_before_destroy = true
     ignore_changes = [
+      "tags.%",
       "tags.kubernetes.io"
     ]
   }


### PR DESCRIPTION
### Overview
* ignore tag counts

### Details
To fully ignore the EKS tags we also need to ignore the count of tags on a resource

### Risk assessment and mitigation
Low

### Performance Impact
None

